### PR TITLE
chore(deps): bump antelope deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3"
+    "@antelopejs/interface-core": "^0.0.6"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.6
+        version: 0.0.6
     devDependencies:
       '@types/node':
         specifier: ^24.12.0
@@ -24,8 +24,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.6':
+    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
@@ -79,7 +79,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.6':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
Bump `@antelopejs/interface-*` (and core) to latest. Template/leaf project: interfaces stay in `dependencies`. Verified: install + build.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps `@antelopejs/interface-core` from `0.0.3` to `0.0.6` in both `package.json` and `pnpm-lock.yaml`. The transitive dependency (`reflect-metadata@0.2.2`) is unchanged.

- `package.json`: version specifier updated from `^0.0.3` → `^0.0.6` (note: for `0.0.x` packages, `^` behaves as an exact pin, so this locks consumers to exactly `0.0.6`).
- `pnpm-lock.yaml`: resolved version and integrity hash updated to match; snapshot shows the same single transitive dep, confirming the dependency tree is stable.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single package bumped, no new dependencies, lock file consistent with the manifest.

The change touches only one package across two files, the lock file is consistent with the new specifier, the transitive dependency tree is identical to before, and ^0.0.x semver pins to an exact version so there is no unintended range widening.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps `@antelopejs/interface-core` specifier from `^0.0.3` to `^0.0.6`; no other changes. |
| pnpm-lock.yaml | Lock file updated to resolve `@antelopejs/interface-core` at `0.0.6` with a new integrity hash; transitive dependency `reflect-metadata@0.2.2` unchanged. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json\n@antelopejs/interface-core"] -->|before| B["^0.0.3\nresolved: 0.0.3"]
    A -->|after| C["^0.0.6\nresolved: 0.0.6"]
    C --> D["reflect-metadata@0.2.2\n(unchanged transitive dep)"]
    B -.->|same transitive dep| D
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json\n@antelopejs/interface-core"] -->|before| B["^0.0.3\nresolved: 0.0.3"]
    A -->|after| C["^0.0.6\nresolved: 0.0.6"]
    C --> D["reflect-metadata@0.2.2\n(unchanged transitive dep)"]
    B -.->|same transitive dep| D
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope deps to lates..."](https://github.com/antelopejs/template-blank-typescript/commit/9764bec261a42c421a8ab9a6293822cea111a4e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37959544)</sub>

<!-- /greptile_comment -->