### PR TITLE
chore: widen Core interface compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.6"
+    "@antelopejs/interface-core": ">=0.0.6 <1.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.6
-        version: 0.0.6
+        specifier: '>=0.0.6 <1.0.0'
+        version: 0.0.11
     devDependencies:
       '@types/node':
         specifier: ^24.12.0
@@ -24,8 +24,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.6':
-    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
+  '@antelopejs/interface-core@0.0.11':
+    resolution: {integrity: sha512-eKE3F9XY0eIzdLBXms8QAY4BHmA8+XXZnta0vZ411q9GiSbI2S1Q3lfYzmnXU4ZK9i+/SIYPplOsA02gIdxODg==}
 
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
@@ -79,7 +79,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.6':
+  '@antelopejs/interface-core@0.0.11':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
## Summary

- widen the `@antelopejs/interface-core` dependency while preserving the existing `0.0.6` minimum
- refresh the lockfile to `@antelopejs/interface-core@0.0.11` for Core 1.5 scaffolds
- keep the template scaffolding, scripts, and documentation unchanged

## Validation

- `pnpm install`
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- real `ajs project init` scaffolds using this branch with Core npm `1.4.7` and Core main `6712035fb9ecbb924b5916788d9bc50123f77a8a`
- clean and frozen installs of both generated projects
- one physical canonical `@antelopejs/interface-core` copy: `0.0.8` with Core npm and `0.0.11` with Core main
- `pnpm run dev` reaches `Done loading` in watch mode in both rows
- `ajs project build` and `ajs project start` succeed in both rows

No packages were published and no provider dependencies were added.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR widens compatibility with `@antelopejs/interface-core` while retaining version 0.0.6 as the minimum.

- Changes the dependency range from `^0.0.6` to `>=0.0.6 <1.0.0`.
- Refreshes the lockfile resolution and integrity metadata to version 0.0.11.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The manifest and lockfile changes are internally consistent, and the repository does not directly import interface-core APIs that could be broken by the updated resolution.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Widens the interface-core dependency range without changing scripts, template metadata, or application behavior. |
| pnpm-lock.yaml | Consistently updates the importer, package entry, and snapshot to interface-core 0.0.11. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): widen core interface compat..."](https://github.com/antelopejs/template-blank-typescript/commit/a14adeb700aa99d0f14684d3c8171e6a4ce7a303) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55588835)</sub>

<!-- /greptile_comment -->